### PR TITLE
:sparkles: Reduce Pod downtime in case of update

### DIFF
--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -22,3 +22,9 @@ spec:
           - $(ENV)
         ports:
           - containerPort: 5678
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5678
+          timeoutSeconds: 3
+          initialDelaySeconds: 15


### PR DESCRIPTION
検討した案:
Pod のダウンタイムを減らす方法として下記 3 つが考えられた:
- A) Pod の readyness をアプリケーションの機能に合うよう定義しておき、ready になった Pod にのみルーティングする
  -  設定が簡単で、特にデメリットを感じないので採用
- B) リクエスト処理中に Pod に停止がかかった場合にアプリケーションが終了する時間的猶予を確保ために.`terminationGracePeriodSeconds` を設定
  - 設定は簡単だが、現状のアプリケーションの処理はとても軽い（`echo` するだけ）のでまだ利用は見送り
- C) k8s のローリングアップデートに頼らず、Pod を新旧 2 系統用意しておき、新しい Pod のデプロイが完了してから Service 側でルーティング先を切り替える（Blue/Green deployment）
  - Blue 用、Green 用の `kustomization.yaml` を用意し、`base` を `production` あるいは `development` とする素朴な運用を思いついたが、組み合わせ数が多くなり運用が煩雑になることが想定されたので、ローリングアップデートに頼ることにした

採用した案: **案 A** （readyness を定義したうえで k8s の Pod ローリングアップデートを利用）

---
close #10