### PR TITLE
:sparkles: Increase resilience to node failures by distributing pods across nodes

### DIFF
--- a/manifest/base/deployment.yaml
+++ b/manifest/base/deployment.yaml
@@ -11,6 +11,16 @@ spec:
     metadata:
       labels:
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - echo-env
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: echo-env
         image: hashicorp/http-echo

--- a/tffile/module/local_infra/cluster_config.tftpl
+++ b/tffile/module/local_infra/cluster_config.tftpl
@@ -16,3 +16,6 @@ nodes:
   - containerPort: 443
     hostPort: ${host_ingress_port_ssh}
     protocol: TCP
+- role: worker
+- role: worker
+- role: worker


### PR DESCRIPTION
Pod が偏りなく配置されるようになった:

```bash
$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE    IP           NODE                  NOMINATED NODE   READINESS GATES
echo-deployment-79cc74f6d8-5q5cn   1/1     Running   0          97m    10.244.3.5   development-worker2   <none>           <none>
echo-deployment-79cc74f6d8-8mj7b   1/1     Running   0          97m    10.244.2.5   development-worker    <none>           <none>
echo-deployment-79cc74f6d8-pxmlq   0/1     Pending   0          96m    <none>       <none>                <none>           <none>
echo-deployment-84d6786b75-bxtvx   1/1     Running   0          102m   10.244.1.5   development-worker3   <none>           <none>

$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE    IP           NODE                  NOMINATED NODE   READINESS GATES
echo-deployment-79cc74f6d8-77rp2   1/1     Running   0          44m    10.244.3.6   development-worker2   <none>           <none>
echo-deployment-79cc74f6d8-8mj7b   1/1     Running   0          147m   10.244.2.5   development-worker    <none>           <none>
echo-deployment-79cc74f6d8-fnrmr   1/1     Running   0          44m    10.244.1.7   development-worker3   <none>           <none>

$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE    IP           NODE                  NOMINATED NODE   READINESS GATES
echo-deployment-79cc74f6d8-8mj7b   1/1     Running   0          148m   10.244.2.5   development-worker    <none>           <none>
echo-deployment-79cc74f6d8-jkpgf   0/1     Running   0          44s    10.244.1.8   development-worker3   <none>           <none>
echo-deployment-79cc74f6d8-t2ncc   0/1     Running   0          43s    10.244.3.7   development-worker2   <none>           <none>

$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE    IP           NODE                  NOMINATED NODE   READINESS GATES
echo-deployment-79cc74f6d8-2sd8d   1/1     Running   0          38m    10.244.1.9   development-worker3   <none>           <none>
echo-deployment-79cc74f6d8-8mj7b   1/1     Running   0          3h7m   10.244.2.5   development-worker    <none>           <none>
echo-deployment-79cc74f6d8-rwnd2   1/1     Running   0          38m    10.244.3.8   development-worker2   <none>           <none>

$ kubectl get pod -o wide
NAME                               READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
echo-deployment-79cc74f6d8-8mj7b   1/1     Running   0          3h14m   10.244.2.5    development-worker    <none>           <none>
echo-deployment-79cc74f6d8-nhtnj   0/1     Running   0          39s     10.244.3.10   development-worker2   <none>           <none>
echo-deployment-79cc74f6d8-tkj89   0/1     Running   0          39s     10.244.1.11   development-worker3   <none>           <none>

```

---
- close #21