### PR TITLE
:wrench: Avoid service downtime by tightening the definition of readyness

### DIFF
--- a/manifest/base/deployment.yaml
+++ b/manifest/base/deployment.yaml
@@ -37,4 +37,4 @@ spec:
             path: /
             port: 5678
           timeoutSeconds: 3
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30


### PR DESCRIPTION
- close #14